### PR TITLE
Compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Even though you can pass most of these options through the command-line interfac
 {
   "dest": "dist/installers/",
   "icon": "resources/Icon.png",
+  "compression": "gzip",
   "categories": [
     "Utility"
   ],
@@ -429,6 +430,14 @@ Default: [`resources/desktop.ejs`](https://github.com/electron-userland/electron
 
 The absolute path to a custom template for the generated [FreeDesktop.org desktop
 entry](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) file.
+
+#### options.compression
+Type: `String`
+Default: `undefined`
+
+Set the compression type used by dpkg-deb when building .deb package
+Allowed values: `'xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none'`
+on error value, default is: `'xz'`
 
 ### Installed Package
 

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Type: `String`
 Default: `package.homepage || package.author.url`
 
 URL of the homepage for the package, used in the [`Homepage` field of the `control` specification](https://www.debian.org/doc/debian-policy/#homepage).
-
+on error value, default is: `'xz'`
 #### options.bin
 Type: `String`
 Default: `package.name || "electron"`
@@ -437,7 +437,6 @@ Default: `undefined`
 
 Set the compression type used by dpkg-deb when building .deb package
 Allowed values: `'xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none'`
-on error value, default is: `'xz'`
 
 ### Installed Package
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -178,7 +178,7 @@ class DebianInstaller extends common.ElectronInstaller {
     // options.compression validation
     const compressionTypes = ['xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none']
     if (this.options.compression && !compressionTypes.includes(this.options.compression)) {
-      this.options.compression = 'xz' // default
+      throw new Error("Compression option should be one of these values: xz, gzip, bzip2, lzma, zstd or none. Please, verify it")
     }
 
     // Create array with unique values from default & user-supplied dependencies

--- a/src/installer.js
+++ b/src/installer.js
@@ -10,7 +10,6 @@ const fsize = promisify(require('get-folder-size'))
 const parseAuthor = require('parse-author')
 const path = require('path')
 const wrap = require('word-wrap')
-const os = require('os')
 
 const debianDependencies = require('./dependencies')
 const spawn = require('./spawn')


### PR DESCRIPTION
Resolves issue https://github.com/electron-userland/electron-installer-debian/issues/272

Se agregó en config.json que se envía como parámetro en la generación de los paquetes .deb (--config={file json}) la posibilidad de definir el tipo de compresión a utilizar

por ejemplo: 
` {
   "compression": "gzip"
}`

Tipo: String
Default: `undefined`

Valores posibles: `'xz', 'gzip', 'bzip2', 'lzma', 'zstd', 'none'`
Si la opción existe en el json pero no se utiliza ninguno de estos valores posibles, se asume default: `'xz'`
Si no se especifica (`undefined`), se utilizará el default que tenga definido la versión de `dpkg-deb` instalada en el S.O.

